### PR TITLE
Add new arg parameter to GenerateTags for configuring output image scale

### DIFF
--- a/src/april/tag/GenerateTags.java
+++ b/src/april/tag/GenerateTags.java
@@ -33,14 +33,22 @@ import java.io.IOException;
 public class GenerateTags {
     public static void main(String args[])
     {
-        if (args.length != 2) {
-            System.out.printf("Usage: <tagclass> <outputdir>\n");
+        if (args.length < 2 || args.length > 3) {
+            System.out.printf("Usage: <tagclass> <outputdir> [<scalefactor>]\n");
             System.out.printf("Example: april.tag.Tag25h11 /tmp/tag25h11\n");
             return;
         }
 
         String cls = args[0];
         String dirpath = args[1] + "/";
+        int scaleFactor = 1;
+        if (args.length > 2) {
+            scaleFactor = Integer.parseInt(args[2]);
+            if (scaleFactor < 1) {
+                System.err.println("Scale factor must be greater or equals 1");
+                return;
+            }
+        }
 
         TagFamily tagFamily = (TagFamily) april.util.ReflectUtil.createObject(cls);
         if (tagFamily == null) {
@@ -56,7 +64,7 @@ public class GenerateTags {
                 f.mkdirs();
 
             renderer.writeAllImagesMosaic(dirpath+"mosaic.png");
-            renderer.writeAllImages(dirpath, tagFamily.getFilePrefix());
+            renderer.writeAllImages(dirpath, tagFamily.getFilePrefix(), scaleFactor);
             renderer.writeAllImagesPostScript(dirpath+"alltags.ps");
         } catch (IOException ex) {
             System.out.println("ex: "+ex);

--- a/src/april/tag/ImageLayout.java
+++ b/src/april/tag/ImageLayout.java
@@ -167,14 +167,15 @@ public class ImageLayout {
         return im2;
     }
 
-    public BufferedImage renderToImage(long code) {
+    public BufferedImage renderToImage(long code, int scaleFactor) {
         int[][] imageData = renderToArray(code);
+        int scaledSize = size * scaleFactor;
 
-        BufferedImage im = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
-        for (int y = 0; y < size; y++) {
-            for (int x = 0; x < size; x++) {
+        BufferedImage im = new BufferedImage(scaledSize, scaledSize, BufferedImage.TYPE_INT_ARGB);
+        for (int y = 0; y < scaledSize; y++) {
+            for (int x = 0; x < scaledSize; x++) {
                 int value;
-                switch(imageData[y][x]) {
+                switch(imageData[y / scaleFactor][x / scaleFactor]) {
                     case 0:
                         value = BLACK;
                         break;

--- a/src/april/tag/TagRenderer.java
+++ b/src/april/tag/TagRenderer.java
@@ -165,10 +165,10 @@ public class TagRenderer {
      * the first block is nbits, the second block is hamming distance,
      * and the final block is the id.
      **/
-    public void writeAllImages(String dirpath, String prefix) throws IOException
+    public void writeAllImages(String dirpath, String prefix, int scaleFactor) throws IOException
     {
         for (int i = 0; i < codes.length; i++) {
-            BufferedImage im = makeImage(i);
+            BufferedImage im = makeImage(i, scaleFactor);
             String fname = String.format("%s_%05d.png",
                     prefix,
                     i);
@@ -180,9 +180,14 @@ public class TagRenderer {
         }
     }
 
-    public BufferedImage makeImage(int id)
+    public BufferedImage makeImage(int id, int scaleFactor)
     {
         long v = codes[id];
-        return layout.renderToImage(v);
+        return layout.renderToImage(v, scaleFactor);
+    }
+
+    public BufferedImage makeImage(int id)
+    {
+        return makeImage(id, 1);
     }
 }


### PR DESCRIPTION
The following command will make apriltags where the size of 1 bit is 32 pixels.

```
java -cp april.jar april.tag.GenerateTags april.tag.Tag36h11 ./tags 32
```

The change is backward compatible, hence running the command without specifying the scale factor will make apriltags where the size of 1 bit is 1 pixel.